### PR TITLE
[WIP] Add OpenGL async depth buffer hack

### DIFF
--- a/Source/Core/VideoBackends/OGL/Render.cpp
+++ b/Source/Core/VideoBackends/OGL/Render.cpp
@@ -966,7 +966,9 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
         RestoreAPIState();
       }
 
-      return 0;
+      return 0; // TODO: replace with something like
+                //       m_depth_buffer[targetPixelRc.left][targetPixelRc.top]
+                //       after properly populating buffer
     }
 
     u32 xRect = x % EFB_CACHE_RECT_SIZE;
@@ -1556,7 +1558,7 @@ void Renderer::DrawEFB(GLuint framebuffer, const TargetRectangle& target_rc,
 {
   TargetRectangle scaled_source_rc = ConvertEFBRectangle(source_rc);
 
-  AsyncUpdateDepthMap();
+  AsyncUpdateDepthBuffer();
 
   // for msaa mode, we must resolve the efb content to non-msaa
   GLuint tex = FramebufferManager::ResolveAndGetRenderTarget(source_rc);
@@ -1564,7 +1566,7 @@ void Renderer::DrawEFB(GLuint framebuffer, const TargetRectangle& target_rc,
   BlitScreen(scaled_source_rc, target_rc, tex, s_target_width, s_target_height);
 }
 
-void Renderer::AsyncUpdateDepthMap()
+void Renderer::AsyncUpdateDepthBuffer()
 {
   glBindBuffer(GL_PIXEL_PACK_BUFFER, m_pboIds[0]);
   glReadPixels(0, 0, EFB_WIDTH, EFB_HEIGHT, GL_DEPTH_COMPONENT, GL_FLOAT, 0);

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -118,7 +118,7 @@ private:
                  const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                  u32 fb_stride, u32 fb_height);
   void DrawEFB(GLuint framebuffer, const TargetRectangle& target_rc, const EFBRectangle& source_rc);
-  void AsyncUpdateDepthMap();
+  void AsyncUpdateDepthBuffer();
   void DrawVirtualXFB(GLuint framebuffer, const TargetRectangle& target_rc, u32 xfb_addr,
                       const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                       u32 fb_stride, u32 fb_height);
@@ -136,6 +136,7 @@ private:
                          u32 fb_stride, u32 fb_height, u64 ticks);
 
   GLuint m_pboIds[1];
+  long m_depth_buffer_size; // TODO: make local to initialization logic
   GLubyte* m_depth_buffer;
 
   // Frame dumping framebuffer, we render to this, then read it back

--- a/Source/Core/VideoBackends/OGL/Render.h
+++ b/Source/Core/VideoBackends/OGL/Render.h
@@ -118,6 +118,7 @@ private:
                  const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                  u32 fb_stride, u32 fb_height);
   void DrawEFB(GLuint framebuffer, const TargetRectangle& target_rc, const EFBRectangle& source_rc);
+  void AsyncUpdateDepthMap();
   void DrawVirtualXFB(GLuint framebuffer, const TargetRectangle& target_rc, u32 xfb_addr,
                       const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                       u32 fb_stride, u32 fb_height);
@@ -133,6 +134,9 @@ private:
   void DumpFrameUsingFBO(const EFBRectangle& source_rc, u32 xfb_addr,
                          const XFBSourceBase* const* xfb_sources, u32 xfb_count, u32 fb_width,
                          u32 fb_stride, u32 fb_height, u64 ticks);
+
+  GLuint m_pboIds[1];
+  GLubyte* m_depth_buffer;
 
   // Frame dumping framebuffer, we render to this, then read it back
   void PrepareFrameDumpRenderTexture(u32 width, u32 height);


### PR DESCRIPTION
**PROBLEM**
On lower-end devices, many Wii games are significantly slowed down because the CPU does EFB access (`PEEK_Z`) on every frame to figure out which object the Wiimote is pointing at. This is so slow in Dolphin because CPU emulation is blocked until the Z depth has been transferred over PCIe using `readPixels()`

**SOLUTION / HACK**
Use a OpenGL PBO to asynchronously download a depth map of the entire framebuffer after rendering frame A. Then, when the CPU asks for a Z coordinate while rendering frame B, return the coordinate that was asynchronously downloaded from frame A. If the transfer is finished before the EFB access, CPU emulation won't be blocked.

While less accurate, I predict this will be practically enough in most games, since they run at 30 or 60FPS and therefore it only takes 33.3 or 16.6 ms longer for the game to respond to the current situation, hardly noticable for the player.

TODO:
- [ ] Solve buffer always being empty
- [ ] Prevent race condition when buffer is read before download is done
- [ ] Make it an option in graphics configuration dialog
- [ ] Ask on IRC if it should be a default for any games and/or platforms